### PR TITLE
Add support for and test against Node.js v0.12 and io.js v2.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,25 +7,35 @@ matrix:
   include:
   - os: linux
     compiler: clang
-    env: FLAVOR=linux CXX=clang++-3.5 BUILDTYPE=Release
+    env:
+    - FLAVOR: linux
+    - CXX: clang++-3.5
+    - NODE_EXE: "node"
+    - NODE_VERSION: 0.10.36
     addons:
       apt:
         sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5' ]
         packages: [ 'gdb', 'clang-3.5', 'libstdc++-4.9-dev', 'libstdc++6', 'libllvm3.4', 'xutils-dev', 'libxxf86vm-dev', 'x11proto-xf86vidmode-dev', 'mesa-utils' ]
   - os: linux
     compiler: gcc
-    env: FLAVOR=linux CXX=g++-4.9 BUILDTYPE=Release
+    env:
+    - FLAVOR: linux
+    - CXX: g++-4.9
+    - NODE_EXE: "node"
+    - NODE_VERSION: 0.10.36
     addons:
       apt:
         sources: [ 'ubuntu-toolchain-r-test' ]
         packages: [ 'gdb', 'g++-4.9', 'gcc-4.9', 'libllvm3.4', 'xutils-dev', 'libxxf86vm-dev', 'x11proto-xf86vidmode-dev', 'mesa-utils' ]
   - os: osx
     compiler: clang
-    env: FLAVOR=osx BUILDTYPE=Release
+    env:
+    - FLAVOR: osx
+    - NODE_EXE: "node"
+    - NODE_VERSION: 0.10.36
 
 env:
   global:
-  - NODE_VERSION: 0.10.36
   - LD_LIBRARY_PATH: "/usr/local/lib"
   - secure: pz/HAMQpnde//JJi3f+RcW32APN6g3QyFAH41JlZwgsM5Daj9RRoXqUcNg4hEyTvlThtc5t+wQQ2ejYAjMwDu00GAzRFJ03Sm45w2fPvith9fu4crXsyPUvWUfWPC0ajTXzorN4cwFwOoMoeo9DihLwb0EC0n4T6jWdBCae3k+s=
   - secure: jYFAOQoMZkZVyc5AFPBKhR9oDqp5CciwCxFhVEHVjdImM+8V60loKazyw+bVLIjzKLnQbKKdiDudWL9TE1ylK/XSlF3K7o4gU2vIh5WzosKnU70Sanxd6tHt/Ui5eK+bAymKHbLdGiXIZtBZE0tML6+wgJ9vhV4ZKna5dM9tps4=

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ matrix:
   - os: linux
     compiler: clang
     env:
-    - FLAVOR: linux
     - CXX: clang++-3.5
     - NODE_EXE: "iojs"
     - NODE_VERSION: 2.0.1
@@ -19,7 +18,6 @@ matrix:
   - os: linux
     compiler: clang
     env:
-    - FLAVOR: linux
     - CXX: clang++-3.5
     - NODE_EXE: "node"
     - NODE_VERSION: 0.12.0
@@ -30,7 +28,6 @@ matrix:
   - os: linux
     compiler: clang
     env:
-    - FLAVOR: linux
     - CXX: clang++-3.5
     - NODE_EXE: "node"
     - NODE_VERSION: 0.10.36
@@ -41,7 +38,6 @@ matrix:
   - os: linux
     compiler: gcc
     env:
-    - FLAVOR: linux
     - CXX: g++-4.9
     - NODE_EXE: "iojs"
     - NODE_VERSION: 2.0.1
@@ -52,7 +48,6 @@ matrix:
   - os: linux
     compiler: gcc
     env:
-    - FLAVOR: linux
     - CXX: g++-4.9
     - NODE_EXE: "node"
     - NODE_VERSION: 0.12.0
@@ -63,7 +58,6 @@ matrix:
   - os: linux
     compiler: gcc
     env:
-    - FLAVOR: linux
     - CXX: g++-4.9
     - NODE_EXE: "node"
     - NODE_VERSION: 0.10.36
@@ -74,19 +68,16 @@ matrix:
   - os: osx
     compiler: clang
     env:
-    - FLAVOR: osx
     - NODE_EXE: "iojs"
     - NODE_VERSION: 2.0.1
   - os: osx
     compiler: clang
     env:
-    - FLAVOR: osx
     - NODE_EXE: "node"
     - NODE_VERSION: 0.12.0
   - os: osx
     compiler: clang
     env:
-    - FLAVOR: osx
     - NODE_EXE: "node"
     - NODE_VERSION: 0.10.36
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - FLAVOR: linux
     - CXX: clang++-3.5
     - NODE_EXE: "iojs"
-    - NODE_VERSION: 1.2.0
+    - NODE_VERSION: 2.0.1
     addons:
       apt:
         sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5' ]
@@ -44,7 +44,7 @@ matrix:
     - FLAVOR: linux
     - CXX: g++-4.9
     - NODE_EXE: "iojs"
-    - NODE_VERSION: 1.2.0
+    - NODE_VERSION: 2.0.1
     addons:
       apt:
         sources: [ 'ubuntu-toolchain-r-test' ]
@@ -76,7 +76,7 @@ matrix:
     env:
     - FLAVOR: osx
     - NODE_EXE: "iojs"
-    - NODE_VERSION: 1.2.0
+    - NODE_VERSION: 2.0.1
   - os: osx
     compiler: clang
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,28 @@ matrix:
     env:
     - FLAVOR: linux
     - CXX: clang++-3.5
+    - NODE_EXE: "iojs"
+    - NODE_VERSION: 1.2.0
+    addons:
+      apt:
+        sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5' ]
+        packages: [ 'gdb', 'clang-3.5', 'libstdc++-4.9-dev', 'libstdc++6', 'libllvm3.4', 'xutils-dev', 'libxxf86vm-dev', 'x11proto-xf86vidmode-dev', 'mesa-utils' ]
+  - os: linux
+    compiler: clang
+    env:
+    - FLAVOR: linux
+    - CXX: clang++-3.5
+    - NODE_EXE: "node"
+    - NODE_VERSION: 0.12.0
+    addons:
+      apt:
+        sources: [ 'ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.5' ]
+        packages: [ 'gdb', 'clang-3.5', 'libstdc++-4.9-dev', 'libstdc++6', 'libllvm3.4', 'xutils-dev', 'libxxf86vm-dev', 'x11proto-xf86vidmode-dev', 'mesa-utils' ]
+  - os: linux
+    compiler: clang
+    env:
+    - FLAVOR: linux
+    - CXX: clang++-3.5
     - NODE_EXE: "node"
     - NODE_VERSION: 0.10.36
     addons:
@@ -21,12 +43,46 @@ matrix:
     env:
     - FLAVOR: linux
     - CXX: g++-4.9
+    - NODE_EXE: "iojs"
+    - NODE_VERSION: 1.2.0
+    addons:
+      apt:
+        sources: [ 'ubuntu-toolchain-r-test' ]
+        packages: [ 'gdb', 'g++-4.9', 'gcc-4.9', 'libllvm3.4', 'xutils-dev', 'libxxf86vm-dev', 'x11proto-xf86vidmode-dev', 'mesa-utils' ]
+  - os: linux
+    compiler: gcc
+    env:
+    - FLAVOR: linux
+    - CXX: g++-4.9
+    - NODE_EXE: "node"
+    - NODE_VERSION: 0.12.0
+    addons:
+      apt:
+        sources: [ 'ubuntu-toolchain-r-test' ]
+        packages: [ 'gdb', 'g++-4.9', 'gcc-4.9', 'libllvm3.4', 'xutils-dev', 'libxxf86vm-dev', 'x11proto-xf86vidmode-dev', 'mesa-utils' ]
+  - os: linux
+    compiler: gcc
+    env:
+    - FLAVOR: linux
+    - CXX: g++-4.9
     - NODE_EXE: "node"
     - NODE_VERSION: 0.10.36
     addons:
       apt:
         sources: [ 'ubuntu-toolchain-r-test' ]
         packages: [ 'gdb', 'g++-4.9', 'gcc-4.9', 'libllvm3.4', 'xutils-dev', 'libxxf86vm-dev', 'x11proto-xf86vidmode-dev', 'mesa-utils' ]
+  - os: osx
+    compiler: clang
+    env:
+    - FLAVOR: osx
+    - NODE_EXE: "iojs"
+    - NODE_VERSION: 1.2.0
+  - os: osx
+    compiler: clang
+    env:
+    - FLAVOR: osx
+    - NODE_EXE: "node"
+    - NODE_VERSION: 0.12.0
   - os: osx
     compiler: clang
     env:

--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,11 @@ $(MBGL)/config/%.gypi: $(MBGL) $(MBGL)/configure
 
 .PHONY: test-suite
 test-suite:
-	-@(`npm bin`/tape test/render.test.js | `npm bin`/tap-spec)
+	-@(`npm bin`/tape test/render.test.js | `npm bin`/faucet)
 
 .PHONY: test-js
 test-js:
-	@(`npm bin`/tape test/js/**/*.test.js | `npm bin`/tap-spec)
+	@(`npm bin`/tape test/js/**/*.test.js | `npm bin`/faucet)
 
 .PHONY: test
 test: test-js test-suite

--- a/binding.gyp
+++ b/binding.gyp
@@ -52,7 +52,6 @@
             '-Werror',
             '-Wall',
             '-Wextra',
-            '-Wshadow',
             '-Wno-variadic-macros',
             '-Wno-error=unused-parameter',
             '-frtti',

--- a/package.json
+++ b/package.json
@@ -18,20 +18,21 @@
     }
   ],
   "dependencies": {
-    "nan": "^1.4.1",
-    "node-pre-gyp": "^0.6.4"
+    "nan": "^1.8.4",
+    "node-pre-gyp": "^0.6.7"
   },
   "bundledDependencies": [
     "node-pre-gyp"
   ],
   "devDependencies": {
-    "aws-sdk": "^2.1.9",
+    "aws-sdk": "^2.1.27",
+    "faucet": "0.0.1",
     "mapbox-gl-test-suite": "git://github.com/mapbox/mapbox-gl-test-suite#master",
-    "mkdirp": "^0.5.0",
-    "request": "^2.53.0",
-    "tap-spec": "^2.2.1",
-    "tape": "^3.5.0",
-    "st": "^0.5.3"
+    "mkdirp": "^0.5.1",
+    "request": "^2.55.0",
+    "st": "^0.5.3",
+    "tap-spec": "^3.0.0",
+    "tape": "^4.0.0"
   },
   "scripts": {
     "install": "node-pre-gyp install || make",

--- a/scripts/install_node.sh
+++ b/scripts/install_node.sh
@@ -4,10 +4,10 @@ set -e
 set -o pipefail
 
 # Mason exists on PATH from sourcing mbgl install script
-mapbox_time "node" \
-mason install node $NODE_VERSION
+mapbox_time $NODE_EXE \
+mason install $NODE_EXE $NODE_VERSION
 
-export PATH="`mason prefix node $NODE_VERSION`/bin":"$PATH"
+export PATH="`mason prefix $NODE_EXE $NODE_VERSION`/bin":"$PATH"
 
-node --version
+$NODE_EXE --version
 npm --version

--- a/src/compress_png.cpp
+++ b/src/compress_png.cpp
@@ -8,15 +8,15 @@ public:
     CompressPNGWorker(NanCallback *callback_, v8::Local<v8::Object> buffer_, uint32_t width_,
                       uint32_t height_)
         : NanAsyncWorker(callback_),
-          buffer(v8::Persistent<v8::Object>::New(buffer_)),
           data(node::Buffer::Data(buffer_)),
           width(width_),
           height(height_) {
+        NanAssignPersistent(buffer, buffer_);
         assert(width * height * 4 == node::Buffer::Length(buffer_));
     }
 
     ~CompressPNGWorker() {
-        buffer.Dispose();
+        NanDisposePersistent(buffer);
     }
 
     void Execute() {

--- a/src/node_file_source.cpp
+++ b/src/node_file_source.cpp
@@ -125,9 +125,7 @@ void NodeFileSource::processCancel(mbgl::Request *req) {
 #endif
 
         // Dispose and remove the persistent handle
-#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
-        // it->second.Reset();
-#else
+#if (NODE_MODULE_VERSION <= NODE_0_10_MODULE_VERSION)
         NanDisposePersistent(it->second);
 #endif
         pending.erase(it);
@@ -155,9 +153,7 @@ void NodeFileSource::notify(mbgl::Request *req, const std::shared_ptr<const mbgl
     // First, remove the request, since it might be destructed at any point now.
     auto it = pending.find(req);
     if (it != pending.end()) {
-#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
-        // it->second.Dispose();
-#else
+#if (NODE_MODULE_VERSION <= NODE_0_10_MODULE_VERSION)
         NanDisposePersistent(it->second);
 #endif
         pending.erase(it);

--- a/src/node_file_source.hpp
+++ b/src/node_file_source.hpp
@@ -46,7 +46,11 @@ private:
     void processCancel(mbgl::Request*);
 
 private:
+#if UV_VERSION_MAJOR == 0 && UV_VERSION_MINOR <= 10
     std::map<mbgl::Request*, v8::Persistent<v8::Object>> pending;
+#else
+    std::map<mbgl::Request*, const v8::UniquePersistent<v8::Object> &> pending;
+#endif
     Queue *queue = nullptr;
 };
 

--- a/src/node_file_source.hpp
+++ b/src/node_file_source.hpp
@@ -6,6 +6,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wshadow"
 #include <node.h>
+#include <node_version.h>
 #include <nan.h>
 #pragma GCC diagnostic pop
 
@@ -46,10 +47,10 @@ private:
     void processCancel(mbgl::Request*);
 
 private:
-#if UV_VERSION_MAJOR == 0 && UV_VERSION_MINOR <= 10
-    std::map<mbgl::Request*, v8::Persistent<v8::Object>> pending;
-#else
+#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
     std::map<mbgl::Request*, const v8::UniquePersistent<v8::Object> &> pending;
+#else
+    std::map<mbgl::Request*, v8::Persistent<v8::Object>> pending;
 #endif
     Queue *queue = nullptr;
 };

--- a/src/node_log.cpp
+++ b/src/node_log.cpp
@@ -32,7 +32,7 @@ NodeLogObserver::NodeLogObserver(v8::Handle<v8::Object> target)
     : queue(new Queue(uv_default_loop(), [this](LogMessage &message) {
           NanScope();
 
-          auto msg = v8::Object::New();
+          auto msg = NanNew<v8::Object>();
           msg->Set(NanNew("class"), NanNew(mbgl::EventClass(message.event).c_str()));
           msg->Set(NanNew("severity"), NanNew(mbgl::EventSeverityClass(message.severity).c_str()));
           if (message.code != -1) {
@@ -49,11 +49,12 @@ NodeLogObserver::NodeLogObserver(v8::Handle<v8::Object> target)
           }
 
           v8::Local<v8::Value> argv[] = { NanNew("message"), msg };
-          auto emit = module->Get(NanNew("emit"))->ToObject();
-          emit->CallAsFunction(module, 2, argv);
+          auto handle = NanNew<v8::Object>(module);
+          auto emit = handle->Get(NanNew("emit"))->ToObject();
+          emit->CallAsFunction(handle, 2, argv);
       })) {
     NanScope();
-    module = v8::Persistent<v8::Object>::New(target);
+    NanAssignPersistent(module, target);
 
     // Don't keep the event loop alive.
     queue->unref();

--- a/src/node_mapbox_gl_native.cpp
+++ b/src/node_mapbox_gl_native.cpp
@@ -11,7 +11,6 @@
 #include "node_request.hpp"
 #include "compress_png.hpp"
 
-
 void RegisterModule(v8::Handle<v8::Object> exports) {
     NanScope();
 
@@ -22,7 +21,7 @@ void RegisterModule(v8::Handle<v8::Object> exports) {
 
     // Exports Resource constants.
     auto ConstantProperty = static_cast<v8::PropertyAttribute>(v8::ReadOnly | v8::DontDelete);
-    auto resource = v8::Object::New();
+    auto resource = NanNew<v8::Object>();
     resource->ForceSet(NanNew("Unknown"), NanNew(mbgl::Resource::Unknown), ConstantProperty);
     resource->ForceSet(NanNew("Tile"), NanNew(mbgl::Resource::Tile), ConstantProperty);
     resource->ForceSet(NanNew("Glyphs"), NanNew(mbgl::Resource::Glyphs), ConstantProperty);

--- a/src/node_request.hpp
+++ b/src/node_request.hpp
@@ -27,7 +27,7 @@ public:
     ////////////////////////////////////////////////////////////////////////////////////////////////
     // Instance
 public:
-    NodeRequest(v8::Persistent<v8::Object> source, mbgl::Request *request);
+    NodeRequest(v8::Local<v8::Object> source, mbgl::Request *request);
     ~NodeRequest();
 
     void cancel();


### PR DESCRIPTION
Would love a code review here from @springmeyer and/or @kkaefer, particularly around how I'm handling [v8::Persistent<T> no longer inheriting from v8::Handle<T>](http://strongloop.com/strongblog/node-js-v0-12-c-apis-breaking/), and [how to adapt code around v8 changes](https://github.com/mapbox/node-mapbox-gl-native/issues/87) (that aren't covered by NAN).

I can't quite seem to figure out how to dispose of `v8::UniquePersistent` either:
- https://github.com/mapbox/node-mapbox-gl-native/blob/ce6106c49f5c162885d7a27f398c826a9f67d92b/src/node_file_source.cpp#L133 
- https://github.com/mapbox/node-mapbox-gl-native/blob/ce6106c49f5c162885d7a27f398c826a9f67d92b/src/node_file_source.cpp#L163

Not sure if this could be related to using [`const v8::UniquePersistent<v8::Object> &`](https://github.com/mapbox/node-mapbox-gl-native/blob/ce6106c49f5c162885d7a27f398c826a9f67d92b/src/node_file_source.hpp#L48) in the `std::map`? This seemed to be necessary to getting `std::move` semantics to work correctly...

> A UniquePersistent<SomeType> handle relies on C++ constructors and destructors to manage the lifetime of the underlying object.
A Persistent<SomeType> can be constructed with its constructor, but must be explicitly cleared with Persistent::Reset.

> Both Persistent and UniquePersistent cannot be copied, which makes them unsuitable as values with pre-C++11 standard library containers. PersistentValueMap and PersistentValueVector provide container classes for persistent values, with map and vector-like semantics. C++11 embedders do not require these, since C++11 move semantics solve the underlying problem.

> https://developers.google.com/v8/embed#handles