### PR TITLE
init display connection on module load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,3 +39,5 @@ after_success:
 
 git:
   submodules: true
+
+sudo: required


### PR DESCRIPTION
Needed to work around `Error choosing pixel format:invalid CoreGraphics connection` when shared display connection is initialized on demand.