### PR TITLE
Handle failed requests

### DIFF
--- a/src/node_map.hpp
+++ b/src/node_map.hpp
@@ -50,6 +50,7 @@ private:
     NodeFileSource &fs;
     mbgl::Map map;
 
+    std::exception_ptr error;
     std::unique_ptr<const mbgl::StillImage> image;
     std::unique_ptr<NanCallback> callback;
 

--- a/test/js/map.test.js
+++ b/test/js/map.test.js
@@ -157,7 +157,6 @@ test('Map', function(t) {
         fileSource.request = function(req) {
             fs.readFile(path.join('test', req.url), function(err, data) {
                 req.respond(err, { data: data });
-                t.error(err);
             });
         };
         fileSource.cancel = function() {};
@@ -196,6 +195,17 @@ test('Map', function(t) {
                     map.render({}, function() {});
                 }, /Style is not set/);
                 t.end();
+            });
+        });
+
+        t.test('returns an error', function(t) {
+            setup(fileSource, function(map) {
+                map.load(style);
+                map.render({ zoom: 1 }, function(err, data) {
+                    t.ok(err);
+                    t.equal(err.message, 'Error rendering image');
+                    t.end();
+                });
             });
         });
 


### PR DESCRIPTION
Return an error if `map.renderStill` returns a `std::exception_ptr`. Refs https://github.com/mapbox/tilelive-gl/issues/25

Waiting on https://github.com/mapbox/mapbox-gl-native/pull/1588 to update submodule before merging.