### PR TITLE
Do not destroy the Map object directly

### DIFF
--- a/src/node_file_source.cpp
+++ b/src/node_file_source.cpp
@@ -4,6 +4,8 @@
 
 #include <mbgl/storage/request.hpp>
 
+#include <algorithm>
+
 namespace node_mbgl {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -42,15 +44,15 @@ NAN_METHOD(NodeFileSource::New) {
 
 struct NodeFileSource::Action {
     const enum : bool { Add, Cancel } type;
-    mbgl::Request *const request;
+    mbgl::Resource const resource;
 };
 
 NodeFileSource::NodeFileSource() :
     queue(new Queue(uv_default_loop(), [this](Action &action) {
         if (action.type == Action::Add) {
-            processAdd(action.request);
+            processAdd(action.resource);
         } else if (action.type == Action::Cancel) {
-            processCancel(action.request);
+            processCancel(action.resource);
         }
     }))
 {
@@ -66,21 +68,50 @@ NodeFileSource::~NodeFileSource() {
 mbgl::Request* NodeFileSource::request(const mbgl::Resource& resource, uv_loop_t* loop, Callback callback) {
     auto req = new mbgl::Request(resource, loop, std::move(callback));
 
-    // This function can be called from any thread. Make sure we're executing the actual call in the
-    // file source loop by sending it over the queue. It will be processed in processAction().
-    queue->send(Action{ Action::Add, req });
+    std::lock_guard<std::mutex> lock(observersMutex);
+    auto it = observers.find(resource);
+    if (it == observers.end()) {
+        observers[resource] = { req };
+
+        // This function can be called from any thread. Make sure we're executing the actual call in the
+        // file source loop by sending it over the queue. It will be processed in processAction().
+        queue->send(Action{ Action::Add, resource });
+    } else {
+        it->second.emplace_back(req);
+    }
+
     return req;
 }
 
 void NodeFileSource::cancel(mbgl::Request* req) {
     req->cancel();
 
-    // This function can be called from any thread. Make sure we're executing the actual call in the
-    // file source loop by sending it over the queue. It will be processed in processAction().
-    queue->send(Action{ Action::Cancel, req });
+    std::lock_guard<std::mutex> lock(observersMutex);
+
+    auto observersIter = observers.find(req->resource);
+    if (observersIter == observers.end()) {
+        return;
+    }
+
+    auto& observersList = observersIter->second;
+    auto observersListIter = std::find(observersList.begin(), observersList.end(), req);
+    if (observersListIter == observersList.end()) {
+        return;
+    }
+
+    observersList.erase(observersListIter);
+    if (observersList.empty()) {
+        observers.erase(observersIter);
+
+        // This function can be called from any thread. Make sure we're executing the actual call in the
+        // file source loop by sending it over the queue. It will be processed in processAction().
+        queue->send(Action{ Action::Cancel, req->resource });
+    }
+
+    req->destruct();
 }
 
-void NodeFileSource::processAdd(mbgl::Request *req) {
+void NodeFileSource::processAdd(const mbgl::Resource& resource) {
     NanScope();
 
     // Make sure the loop stays alive as long as request is pending.
@@ -89,23 +120,23 @@ void NodeFileSource::processAdd(mbgl::Request *req) {
     }
 
     auto handle = NanObjectWrapHandle(this);
-    auto requestHandle = NanNew<v8::Object>(NodeRequest::Create(handle, req));
+    auto requestHandle = NanNew<v8::Object>(NodeRequest::Create(handle, resource));
 #if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
     const v8::UniquePersistent<v8::Object> requestPersistent(v8::Isolate::GetCurrent(), requestHandle);
 #else
     v8::Persistent<v8::Object> requestPersistent;
     NanAssignPersistent(requestPersistent, requestHandle);
 #endif
-    pending.emplace(req, std::move(requestPersistent));
+    pending.emplace(resource, std::move(requestPersistent));
 
     v8::Local<v8::Value> argv[] = { requestHandle };
     NanMakeCallback(handle, NanNew("request"), 1, argv);
 }
 
-void NodeFileSource::processCancel(mbgl::Request *req) {
+void NodeFileSource::processCancel(const mbgl::Resource& resource) {
     NanScope();
 
-    auto it = pending.find(req);
+    auto it = pending.find(resource);
     if (it == pending.end()) {
         // The response callback was already fired. There is no point in calling the cancelation
         // callback because the request is already completed.
@@ -136,14 +167,11 @@ void NodeFileSource::processCancel(mbgl::Request *req) {
         // Set the request handle in the request wrapper handle to null
         ObjectWrap::Unwrap<NodeRequest>(requestHandle)->cancel();
     }
-
-    // Finally, destruct the request object
-    req->destruct();
 }
 
-void NodeFileSource::notify(mbgl::Request *req, const std::shared_ptr<const mbgl::Response>& response) {
+void NodeFileSource::notify(const mbgl::Resource& resource, const std::shared_ptr<const mbgl::Response>& response) {
     // First, remove the request, since it might be destructed at any point now.
-    auto it = pending.find(req);
+    auto it = pending.find(resource);
     if (it != pending.end()) {
 #if (NODE_MODULE_VERSION <= NODE_0_10_MODULE_VERSION)
         NanDisposePersistent(it->second);
@@ -156,7 +184,23 @@ void NodeFileSource::notify(mbgl::Request *req, const std::shared_ptr<const mbgl
         }
     }
 
-    req->notify(response);
+    std::vector<mbgl::Request*> observersList;
+
+    {
+        std::lock_guard<std::mutex> lock(observersMutex);
+
+        auto observersIter = observers.find(resource);
+        if (observersIter == observers.end()) {
+            return;
+        }
+
+        observersList.swap(observersIter->second);
+        observers.erase(observersIter);
+    }
+
+    for (auto request : observersList) {
+        request->notify(response);
+    }
 }
 
 }

--- a/src/node_file_source.hpp
+++ b/src/node_file_source.hpp
@@ -49,7 +49,7 @@ private:
 
 private:
 #if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
-    std::unordered_map<mbgl::Resource, const v8::UniquePersistent<v8::Object> &, mbgl::Resource::Hash> pending;
+    std::unordered_map<mbgl::Resource, v8::Persistent<v8::Object, v8::CopyablePersistentTraits<v8::Object>>, mbgl::Resource::Hash> pending;
 #else
     std::unordered_map<mbgl::Resource, v8::Persistent<v8::Object>, mbgl::Resource::Hash> pending;
 #endif

--- a/src/node_file_source.hpp
+++ b/src/node_file_source.hpp
@@ -10,8 +10,10 @@
 #include <nan.h>
 #pragma GCC diagnostic pop
 
-#include <map>
 #include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
 
 namespace node_mbgl {
 
@@ -36,21 +38,32 @@ public:
     void cancel(mbgl::Request*);
 
     // visiblity?
-    void notify(mbgl::Request*, const std::shared_ptr<const mbgl::Response>&);
+    void notify(const mbgl::Resource&, const std::shared_ptr<const mbgl::Response>&);
 
 private:
     struct Action;
     using Queue = util::AsyncQueue<Action>;
 
-    void processAdd(mbgl::Request*);
-    void processCancel(mbgl::Request*);
+    void processAdd(const mbgl::Resource&);
+    void processCancel(const mbgl::Resource&);
 
 private:
 #if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
-    std::map<mbgl::Request*, const v8::UniquePersistent<v8::Object> &> pending;
+    std::unordered_map<mbgl::Resource, const v8::UniquePersistent<v8::Object> &, mbgl::Resource::Hash> pending;
 #else
-    std::map<mbgl::Request*, v8::Persistent<v8::Object>> pending;
+    std::unordered_map<mbgl::Resource, v8::Persistent<v8::Object>, mbgl::Resource::Hash> pending;
 #endif
+
+    // The observers list will hold pointers to all the requests waiting
+    // for a particular resource. It is also used for coalescing requests,
+    // so we don't ask for the same resources twice. The access must be
+    // guarded by a mutex because the list is also accessed by a thread
+    // from the mbgl::Map object and from the main thread when notifying
+    // requests of completion. Concurrent access is specially needed when
+    // canceling a request to avoid a deadlock (see #129).
+    std::unordered_map<mbgl::Resource, std::vector<mbgl::Request*>, mbgl::Resource::Hash> observers;
+    std::mutex observersMutex;
+
     Queue *queue = nullptr;
 };
 

--- a/src/node_request.hpp
+++ b/src/node_request.hpp
@@ -7,8 +7,11 @@
 #include <nan.h>
 #pragma GCC diagnostic pop
 
+#include <mbgl/storage/resource.hpp>
+
+#include <memory>
+
 class NodeFileSource;
-namespace mbgl { class Request; }
 
 namespace node_mbgl {
 
@@ -20,21 +23,21 @@ public:
     static NAN_METHOD(New);
     static NAN_METHOD(Respond);
 
-    static v8::Handle<v8::Object> Create(v8::Handle<v8::Object> source, mbgl::Request *request);
+    static v8::Handle<v8::Object> Create(v8::Handle<v8::Object> source, const mbgl::Resource& resource);
 
     static v8::Persistent<v8::FunctionTemplate> constructorTemplate;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
     // Instance
 public:
-    NodeRequest(v8::Local<v8::Object> source, mbgl::Request *request);
+    NodeRequest(v8::Local<v8::Object> source, const mbgl::Resource& resource);
     ~NodeRequest();
 
     void cancel();
 
 private:
     v8::Persistent<v8::Object> source;
-    mbgl::Request *request = nullptr;
+    std::unique_ptr<mbgl::Resource> resource;
 };
 
 }

--- a/test/js/gzip.test.js
+++ b/test/js/gzip.test.js
@@ -104,7 +104,7 @@ test('gzip', function(t) {
         mbgl.once('message', function(msg) {
             if (msg.severity == 'ERROR') {
                 t.ok(msg, 'emits error');
-                t.equal(msg.class, 'ResourceLoader');
+                t.equal(msg.class, 'Style');
                 t.equal(msg.severity, 'ERROR');
                 t.ok(msg.text.match(/pbf unknown field type exception/), 'error text matches');
             }

--- a/test/js/map.test.js
+++ b/test/js/map.test.js
@@ -220,10 +220,10 @@ test('Map', function(t) {
             });
         });
 
-        t.skip('returns an error', function(t) {
+        t.test('returns an error', function(t) {
             mbgl.on('message', function(msg) {
                 t.ok(msg, 'emits error');
-                t.equal(msg.class, 'ResourceLoader');
+                t.equal(msg.class, 'Style');
                 t.equal(msg.severity, 'ERROR');
                 t.ok(msg.text.match(/Failed to load/), 'error text matches');
             });


### PR DESCRIPTION
Destroying the Map object directly can cause the main thread to hang in case we need to cancel a request.

When we make NodeFileSource a request, we invoke a callback that is set on the JavaScript code that is likely to map to some network request or read a file on the filesystem asynchronously. If we destroy the Map object before the request gets answered, the Map object will ask the NodeFileSource to cancel the request and wait.

This will never happen because since the Map object destruction is synchronous and is initiated from the main thread, the NodeFileSource will never have a chance to return to cancel the request, because it is also living on the main thread (that is now blocked).

Letting the GC decide when it is fine to destroy these objects is probably a better option because it will take care of these dependencies.

Effectively, filesource.cancel is never called.