### PR TITLE
segfault instead of JS error requiring style to be set

### DIFF
--- a/src/node_map.cpp
+++ b/src/node_map.cpp
@@ -102,6 +102,10 @@ NAN_METHOD(NodeMap::Load) {
 
     if (!nodeMap->isValid()) return NanThrowError(releasedMessage());
 
+    // Reset the flag as this could be the second time
+    // we are calling this (being the previous successful).
+    nodeMap->loaded = false;
+
     if (args.Length() < 1) {
         return NanThrowError("Requires a map style as first argument");
     }
@@ -121,6 +125,8 @@ NAN_METHOD(NodeMap::Load) {
     } catch (const std::exception &ex) {
         return NanThrowError(ex.what());
     }
+
+    nodeMap->loaded = true;
 
     NanReturnUndefined();
 }
@@ -166,6 +172,10 @@ NAN_METHOD(NodeMap::Render) {
 
     if (args.Length() <= 1 || !args[1]->IsFunction()) {
         return NanThrowTypeError("Second argument must be a callback function");
+    }
+
+    if (!nodeMap->isLoaded()) {
+        return NanThrowTypeError("Style is not loaded");
     }
 
     auto options = ParseOptions(args[0]->ToObject());

--- a/src/node_map.hpp
+++ b/src/node_map.hpp
@@ -33,6 +33,8 @@ public:
     void renderFinished();
 
     void release();
+
+    inline bool isLoaded() { return loaded; }
     inline bool isValid() { return valid; }
 
     static std::unique_ptr<NodeMap::RenderOptions> ParseOptions(v8::Local<v8::Object> obj);
@@ -60,6 +62,7 @@ private:
     // Async for delivering the notifications of render completion.
     uv_async_t *async;
 
+    bool loaded = false;
     bool valid = true;
 };
 

--- a/test/js/gzip.test.js
+++ b/test/js/gzip.test.js
@@ -116,7 +116,7 @@ test('gzip', function(t) {
                 map.release();
 
                 t.ok(err, 'returns error');
-                t.equal(err.message, 'Error rendering image');
+                t.ok(err.message.match(/Failed to parse/), 'error text matches');
 
                 t.end();
             });

--- a/test/js/map.test.js
+++ b/test/js/map.test.js
@@ -338,11 +338,11 @@ test('Map', function(t) {
             });
         });
 
-        t.skip('requires a style to be set', function(t) {
+        t.test('requires a style to be set', function(t) {
             setup(fileSource, function(map) {
                 t.throws(function() {
                     map.render({}, function() {});
-                }, /Style is not set/);
+                }, /Style is not loaded/);
 
                 map.release();
 
@@ -365,7 +365,7 @@ test('Map', function(t) {
                     map.release();
 
                     t.ok(err, 'returns error');
-                    t.equal(err.message, 'Error rendering image');
+                    t.ok(err.message.match(/Failed to load/), 'error text matches');
 
                     t.end();
                 });


### PR DESCRIPTION
Captured in (skipped) test [`requires a style to be set`](https://github.com/mapbox/node-mapbox-gl-native/blob/master/test/js/map.test.js#L211-L221) in [test/js/map.test.js](https://github.com/mapbox/node-mapbox-gl-native/blob/master/test/js/map.test.js).

Backtrace:
```
# requires a style to be set
Process 29142 stopped
* thread #10: tid = 0x71de4, 0x00007fff8d6d9dc6 libc++.1.dylib`std::exception_ptr::exception_ptr(std::exception_ptr const&) + 4, name = 'Map', stop reason = E
XC_BAD_ACCESS (code=1, address=0x88)
    frame #0: 0x00007fff8d6d9dc6 libc++.1.dylib`std::exception_ptr::exception_ptr(std::exception_ptr const&) + 4
libc++.1.dylib`std::exception_ptr::exception_ptr:
->  0x7fff8d6d9dc6 <+4>:  movq   (%rsi), %rax
    0x7fff8d6d9dc9 <+7>:  movq   %rax, (%rdi)
    0x7fff8d6d9dcc <+10>: movq   %rax, %rdi
    0x7fff8d6d9dcf <+13>: popq   %rbp
(lldb) bt
* thread #10: tid = 0x71de4, 0x00007fff8d6d9dc6 libc++.1.dylib`std::exception_ptr::exception_ptr(std::exception_ptr const&) + 4, name = 'Map', stop reason = E
XC_BAD_ACCESS (code=1, address=0x88)
  * frame #0: 0x00007fff8d6d9dc6 libc++.1.dylib`std::exception_ptr::exception_ptr(std::exception_ptr const&) + 4
    frame #1: 0x000000010323c482 mapbox-gl-native.node`mbgl::MapContext::renderStill(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::S
tillImage const, std::__1::default_delete<mbgl::StillImage const> >)>) [inlined] mbgl::Style::getLastError(this=<unavailable>) const + 98 at style.hpp:63
    frame #2: 0x000000010323c46f mapbox-gl-native.node`mbgl::MapContext::renderStill(this=0x0000000110370c90, fn=mbgl::MapContext::StillImageCallback at 0x000
0000110368590)>) + 79 at map_context.cpp:184
    frame #3: 0x000000010323ab1e mapbox-gl-native.node`void mbgl::util::RunLoop::Invoker<auto mbgl::util::Thread<mbgl::MapContext>::bind<void (mbgl::MapContex
t::*)(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)>), std::__
1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)>&>(void (mbgl::MapConte
xt::*)(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)>))::'lamb
da'(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)>&), std::__1::tuple<std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)> >, std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)>&>::invoke<0ul>(std::__1::integer_sequence<unsigned long, 0ul>) [inlined] auto mbgl::util::Thread<mbgl::MapContext>::bind<void (a=<unavailable>)(std::__1::function<void (std::exc
eption_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)>), std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)>&>(void (mbgl::MapContext::*)(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)>))::'lambda'(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)>&)::operator()(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)>&) const + 85 at thread.hpp:80
    frame #4: 0x000000010323aac9 mapbox-gl-native.node`void mbgl::util::RunLoop::Invoker<auto mbgl::util::Thread<mbgl::MapContext>::bind<void (mbgl::MapContext::*)(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)>), std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)>&>(void (mbgl::MapConte
xt::*)(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)>))::'lamb
da'(std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)>&), std::__1
::tuple<std::__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)> >, std:
:__1::function<void (std::exception_ptr, std::__1::unique_ptr<mbgl::StillImage const, std::__1::default_delete<mbgl::StillImage const> >)>&>::invoke<0ul>(this
=<unavailable>, (null)=<unavailable>) + 41 at run_loop.hpp:82
    frame #5: 0x00000001032be4a7 mapbox-gl-native.node`mbgl::util::RunLoop::process(this=<unavailable>) + 311 at run_loop.cpp:27
    frame #6: 0x000000010043ef18 node`uv__async_event + 64
    frame #7: 0x000000010043f09c node`uv__async_io + 136
    frame #8: 0x000000010044bb74 node`uv__io_poll + 1503
    frame #9: 0x000000010043f4e1 node`uv_run + 239
    frame #10: 0x000000010323b223 mapbox-gl-native.node`void mbgl::util::Thread<mbgl::MapContext>::run<std::__1::tuple<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>, 0ul, 1ul, 2ul>(std::__1::tuple<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>&&, std::__1::integer_sequence<unsigned long, 0ul, 1ul, 2ul>) [inlined] uv::loop::run() + 131 at uv_detail.hpp:55
    frame #11: 0x000000010323b219 mapbox-gl-native.node`void mbgl::util::Thread<mbgl::MapContext>::run<std::__1::tuple<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>, 0ul, 1ul, 2ul>(this=0x000000010312a290, params=<unavailable>, (null)=<unavailable>) + 121 at thread.hpp:132
    frame #12: 0x000000010323b14f mapbox-gl-native.node`std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()> >(void*, void*) [inlined] mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()::operator()() const + 143 at thread.hpp:113
    frame #13: 0x000000010323b11e mapbox-gl-native.node`std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()> >(void*, void*) [inlined] std::__1::__invoke<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()>(decltype(std::__1::forward<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()>(fp)(std::__1::forward<>(fp0))), mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()&&) + 3 at __functional_base:413
    frame #14: 0x000000010323b11b mapbox-gl-native.node`std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()> >(void*, void*) [inlined] _ZNSt3__116__thread_executeIZN4mbgl4util6ThreadINS1_10MapContextEEC1IJRNS1_4ViewERNS1_10FileSourceERNS1_7MapDataEEEERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEENS2_14ThreadPriorityEDpOT_EUlvE_JEJEEEvRNS_5tupleIJT_DpT0_EEENS_15__tuple_indicesIJXspT1_EEEE at thread:332
    frame #15: 0x000000010323b11b mapbox-gl-native.node`std::__1::__thread_proxy<std::__1::tuple<mbgl::util::Thread<mbgl::MapContext>::Thread<mbgl::View&, mbgl::FileSource&, mbgl::MapData&>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, mbgl::util::ThreadPriority, mbgl::View&&&, mbgl::FileSource&&&, mbgl::MapData&&&)::'lambda'()> >(__vp=0x00000001031526f0) + 91 at thread:342
    frame #16: 0x00007fff87975268 libsystem_pthread.dylib`_pthread_body + 131
    frame #17: 0x00007fff879751e5 libsystem_pthread.dylib`_pthread_start + 176
    frame #18: 0x00007fff8797341d libsystem_pthread.dylib`thread_start + 13
```