### PR TITLE
resize HeadlessView directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     }
   ],
   "dependencies": {
-    "mapbox-gl-test-suite": "git://github.com/mapbox/mapbox-gl-test-suite#7251829de9d2804fe02cd8f7acc0e30ea278429d",
     "nan": "^1.9.0",
     "node-pre-gyp": "^0.6.7"
   },
@@ -28,7 +27,7 @@
   "devDependencies": {
     "aws-sdk": "^2.1.27",
     "faucet": "0.0.1",
-    "mapbox-gl-test-suite": "git://github.com/mapbox/mapbox-gl-test-suite#master",
+    "mapbox-gl-test-suite": "git://github.com/mapbox/mapbox-gl-test-suite#7251829de9d2804fe02cd8f7acc0e30ea278429d",
     "mkdirp": "^0.5.1",
     "pngjs": "^0.4.0",
     "request": "^2.55.0",

--- a/src/node_map.cpp
+++ b/src/node_map.cpp
@@ -192,7 +192,7 @@ NAN_METHOD(NodeMap::Render) {
 }
 
 void NodeMap::startRender(std::unique_ptr<NodeMap::RenderOptions> options) {
-    map->resize(options->width, options->height, options->ratio);
+    view.resize(options->width, options->height);
     map->setClasses(options->classes);
     map->setLatLngZoom(mbgl::LatLng(options->latitude, options->longitude), options->zoom);
     map->setBearing(options->bearing);
@@ -319,7 +319,7 @@ void NodeMap::release() {
 // Instance
 
 NodeMap::NodeMap(v8::Handle<v8::Object> options) :
-    view(sharedDisplay()),
+    view(sharedDisplay(), 1.0),
     fs(options),
     map(std::make_unique<mbgl::Map>(view, fs, mbgl::MapMode::Still)),
     async(new uv_async_t) {

--- a/test/js/consecutive.test.js
+++ b/test/js/consecutive.test.js
@@ -24,6 +24,7 @@ function renderTest(style, info, dir, key) {
             });
         };
         options.cancel = function() {};
+        options.ratio = 1.0;
 
         var map = new mbgl.Map(options);
         map.load(style);
@@ -50,7 +51,7 @@ function rewriteLocalSchema(uri) {
     return uri.replace(/^local:\/\//, '');
 }
 
-test('Concurrency', function(t) {
+test('Consecutive', function(t) {
     var dir = 'line-join';
     var k = 'round';
 

--- a/test/js/gzip.test.js
+++ b/test/js/gzip.test.js
@@ -50,7 +50,8 @@ function getOptions(gzip, t) {
                 response.data = res.body;
                 req.respond(null, response);
             });
-        }
+        },
+        ratio: 1.0
     };
 }
 

--- a/test/js/map.test.js
+++ b/test/js/map.test.js
@@ -65,6 +65,16 @@ test('Map', function(t) {
             }, /Options object 'cancel' property must be a function/);
 
             options.cancel = function() {};
+            t.throws(function() {
+                new mbgl.Map(options);
+            }, /Options object must have a numerical 'ratio' property/);
+
+            options.ratio = 'test';
+            t.throws(function() {
+                new mbgl.Map(options);
+            }, /Options object must have a numerical 'ratio' property/);
+
+            options.ratio = 1.0;
             t.doesNotThrow(function() {
                 new mbgl.Map(options);
             });
@@ -79,6 +89,7 @@ test('Map', function(t) {
         var options = {};
         options.request = function() {};
         options.cancel = function() {};
+        options.ratio = 1.0;
 
         t.test('requires a string or object as the first parameter', function(t) {
             t.test('requires a map style as first argument', function(t) {
@@ -159,6 +170,7 @@ test('Map', function(t) {
             });
         };
         options.cancel = function() {};
+        options.ratio = 1.0;
 
         t.test('requires an object as the first parameter', function(t) {
             setup(options, function(map) {

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -47,6 +47,7 @@ function renderTest(style, info, base, key) {
             });
         };
         options.cancel = function() {};
+        options.ratio = 1.0;
 
         var map = new mbgl.Map(options);
         map.load(style);


### PR DESCRIPTION
Bumps mbgl core lib to latest stable release [v0.5.1](https://github.com/mapbox/mapbox-gl-native/releases/tag/v0.5.1), initializes `view` with immutable pixel ratio and attempts to resize `HeadlessView` directly rather than through deprecated `Map::resize` method.

Currently trying to figure out why concurrent requests are triggering the following errors:
- ~~[`Error: Request has already been responded to, or was canceled`](https://github.com/mapbox/node-mapbox-gl-native/blob/ba09ea9ef9c53bc6759abac66e84ce9115cb4c5c/src/node_request.cpp#L61)~~
- [`std::runtime_error what():  OpenGL context was not current`](https://github.com/mapbox/mapbox-gl-native/blob/970ad1fe1b25cd2fc6e33f84e890ddd90f6874f3/platform/default/headless_view.cpp#L273-L275)
  - I'm guessing this is from trying to deactivate an inactive view prior to [`HeadlessView::resize`](https://github.com/mapbox/mapbox-gl-native/blob/970ad1fe1b25cd2fc6e33f84e890ddd90f6874f3/platform/default/headless_view.cpp#L117-L162), but dropping this line **sometimes** results in [`libc++abi.dylib: terminating with uncaught exception of type std::runtime_error: OpenGL context was already current`](https://github.com/mapbox/mapbox-gl-native/blob/970ad1fe1b25cd2fc6e33f84e890ddd90f6874f3/platform/default/headless_view.cpp#L247-L249) - is there a more intelligent way to make sure a view is inactive before calling `HeadlessView::resize`?

This is an alternative to exposing a public `NodeView` object and [swapping in views from a cache](https://github.com/mapbox/node-mapbox-gl-native/issues/142).

/cc @jfirebaugh @tmpsantos 